### PR TITLE
Add tooltips in W95 style.

### DIFF
--- a/css/pixel.css
+++ b/css/pixel.css
@@ -7684,8 +7684,21 @@ a:hover,
 }
 
 .tooltip-inner {
-    box-shadow: 0 0.5rem 1rem rgba(42, 53, 79, 0.12);
+    background-color: #ffffe3;
+    border-radius: 0%;
+    color: #000;
+    border: 1px solid #000;
+    box-shadow: 3px 3px 0px 0px rgba(0,0,0,0.75);
 }
 
+.tooltip .arrow:before {
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    border-left-color: transparent;
+    border-right-color: transparent;
+}
 
+.tooltip.show {
+    opacity: 1;
+}
 /*# sourceMappingURL=pixel.css.map */

--- a/index.html
+++ b/index.html
@@ -501,6 +501,17 @@
         </section>
         <section class="section-sm">
             <div class="container">
+                <div class="row mt-5 mt-lg-2">
+                    <div class="col-lg-12">
+                        <h4 class="mb-5">Tooltips</h4>
+                        <button class="btn mr-2 mb-2 btn-primary" type="button" data-toggle="tooltip" data-placement="top" title="The quick brown fox jumps over the lazy dog."><span
+                                class="btn-text">Button</span></button>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <section class="section-sm">
+            <div class="container">
                 <div class="mt-5 mb-5 mt-md-0">
                     <h4>Typography</h4>
                 </div>
@@ -721,6 +732,7 @@
     </footer>
 
     <!-- Core -->
+    <script src="node_modules/popper.js/dist/umd/popper.min.js"></script>
     <script src="node_modules/jquery/dist/jquery.min.js"></script>
     <script src="node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "jquery": "^3.4.1",
-    "popper": "^1.0.1"
+    "popper.js": "^1.0.1"
   }
 }


### PR DESCRIPTION
A simple implementation of the iconic butter-color W95 tooltip with black border&shadow, which can be attached to all sides (left-top-right-bottom) for the elements. 